### PR TITLE
fix(light): initialize color and led_effect defaults in async_turn_on

### DIFF
--- a/custom_components/oasis_mini/light.py
+++ b/custom_components/oasis_mini/light.py
@@ -144,12 +144,14 @@ class OasisDeviceLightEntity(OasisDeviceEntity, LightEntity):
         else:
             brightness = self.device.brightness_on
 
-        if color := kwargs.get(ATTR_RGB_COLOR):
-            color = f"#{color_rgb_to_hex(*color)}"
+        color = None
+        if rgb := kwargs.get(ATTR_RGB_COLOR):
+            color = f"#{color_rgb_to_hex(*rgb)}"
 
-        if led_effect := kwargs.get(ATTR_EFFECT):
+        led_effect = None
+        if effect := kwargs.get(ATTR_EFFECT):
             led_effect = next(
-                (k for k, v in LED_EFFECTS.items() if v == led_effect), None
+                (k for k, v in LED_EFFECTS.items() if v == effect), None
             )
 
         await self.device.async_set_led(

--- a/custom_components/oasis_mini/light.py
+++ b/custom_components/oasis_mini/light.py
@@ -150,9 +150,7 @@ class OasisDeviceLightEntity(OasisDeviceEntity, LightEntity):
 
         led_effect = None
         if effect := kwargs.get(ATTR_EFFECT):
-            led_effect = next(
-                (k for k, v in LED_EFFECTS.items() if v == effect), None
-            )
+            led_effect = next((k for k, v in LED_EFFECTS.items() if v == effect), None)
 
         await self.device.async_set_led(
             brightness=brightness, color=color, led_effect=led_effect


### PR DESCRIPTION
When `light.turn_on` is called without `ATTR_RGB_COLOR` or `ATTR_EFFECT`, the walrus assignment inside the `if` never runs, so `color` and `led_effect` are unbound when passed to `async_set_led`. Initializing both to `None` up front matches the pattern used by other Home Assistant light integrations and keeps the existing kwarg-shortcircuit behavior intact.

Fixes #137

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal code organization for light control settings to enhance clarity and maintainability, with no changes to user-facing functionality.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/natekspencer/ha-oasis-control/pull/140)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->